### PR TITLE
Set correct path for transforms in node_modules

### DIFF
--- a/src/main/resources/META-INF/rewrite/material-ui.yml
+++ b/src/main/resources/META-INF/rewrite/material-ui.yml
@@ -16,8 +16,8 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.All
 displayName: Combination of all deprecations
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#all)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#all).
 tags:
   - codemods
   - material-ui
@@ -30,1091 +30,1091 @@ recipeList:
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.SxProp
 displayName: Update the usage of the `sx` prop to be compatible with `@pigment-css/react`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#sx-prop)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#sx-prop).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v6.0.0/sx-prop"
+      transform: "@mui/codemod/node/v6.0.0/sx-prop"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.SystemProps
 displayName: Remove system props and add them to the `sx` prop
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#system-props)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#system-props).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v6.0.0/system-props"
+      transform: "@mui/codemod/node/v6.0.0/system-props"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.ThemeV
 displayName: Update the theme creation from `@mui/system@v5` to be compatible with `@pigment-css/react`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-v6)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-v6).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v6.0.0/theme-v6"
+      transform: "@mui/codemod/node/v6.0.0/theme-v6"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.Styled
 displayName: Updates the usage of `styled` from `@mui/system@v5` to be compatible with` @pigment-css/react`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#styled)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#styled).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v6.0.0/styled"
+      transform: "@mui/codemod/node/v6.0.0/styled"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.GridVProps
 displayName: Updates the usage of the `@mui/material/Grid2`, `@mui/system/Grid`, and `@mui/joy/Grid` components to their updated APIs.
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#grid-v2-props)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#grid-v2-props).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v6.0.0/grid-v2-props"
+      transform: "@mui/codemod/node/v6.0.0/grid-v2-props"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.AdapterV
 displayName: Converts components to use the v4 adapter module
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#adapter-v4)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#adapter-v4).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/adapter-v4"
+      transform: "@mui/codemod/node/v5.0.0/adapter-v4"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.AutocompleteRenameCloseicon
 displayName: Renames `closeIcon` prop to `closeButtonIcon`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#autocomplete-rename-closeicon)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#autocomplete-rename-closeicon).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/autocomplete-rename-closeicon"
+      transform: "@mui/codemod/node/v5.0.0/autocomplete-rename-closeicon"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.AutocompleteRenameOption
 displayName: Renames `option` prop to `getOptionLabel`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#autocomplete-rename-option)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#autocomplete-rename-option).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/autocomplete-rename-option"
+      transform: "@mui/codemod/node/v5.0.0/autocomplete-rename-option"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.AvatarCircleCircular
 displayName: Updates `circle` prop to `variant="circular"`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#avatar-circle-circular)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#avatar-circle-circular).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/avatar-circle-circular"
+      transform: "@mui/codemod/node/v5.0.0/avatar-circle-circular"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.BadgeOverlapValue
 displayName: Updates `overlap` prop to `variant="dot"`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#badge-overlap-value)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#badge-overlap-value).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/badge-overlap-value"
+      transform: "@mui/codemod/node/v5.0.0/badge-overlap-value"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.BaseHookImports
 displayName: Converts base imports to use React hooks
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#base-hook-imports)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#base-hook-imports).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/base-hook-imports"
+      transform: "@mui/codemod/node/v5.0.0/base-hook-imports"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.BaseRemoveComponentProp
 displayName: Removes `component` prop from base components
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#base-remove-component-prop)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#base-remove-component-prop).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/base-remove-component-prop"
+      transform: "@mui/codemod/node/v5.0.0/base-remove-component-prop"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.BaseRemoveUnstyledSuffix
 displayName: Removes `Unstyled` suffix from base components
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#base-remove-unstyled-suffix)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#base-remove-unstyled-suffix).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/base-remove-unstyled-suffix"
+      transform: "@mui/codemod/node/v5.0.0/base-remove-unstyled-suffix"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.BaseRenameComponentsToSlots
 displayName: Renames base components to slots
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#base-rename-components-to-slots)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#base-rename-components-to-slots).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/base-rename-components-to-slots"
+      transform: "@mui/codemod/node/v5.0.0/base-rename-components-to-slots"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.BaseUseNamedExports
 displayName: Updates base imports to use named exports
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#base-use-named-exports)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#base-use-named-exports).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/base-use-named-exports"
+      transform: "@mui/codemod/node/v5.0.0/base-use-named-exports"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.BoxBorderradiusValues
 displayName: Updates `borderRadius` prop values
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#box-borderradius-values)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#box-borderradius-values).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/box-borderradius-values"
+      transform: "@mui/codemod/node/v5.0.0/box-borderradius-values"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.BoxRenameCss
 displayName: Renames CSS properties for Box component
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#box-rename-css)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#box-rename-css).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/box-rename-css"
+      transform: "@mui/codemod/node/v5.0.0/box-rename-css"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.BoxRenameGap
 displayName: Renames `gap` prop to `spacing`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#box-rename-gap)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#box-rename-gap).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/box-rename-gap"
+      transform: "@mui/codemod/node/v5.0.0/box-rename-gap"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.BoxSxProp
 displayName: Converts `sx` prop to `sx` style prop
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#box-sx-prop)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#box-sx-prop).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/box-sx-prop"
+      transform: "@mui/codemod/node/v5.0.0/box-sx-prop"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.ButtonColorProp
 displayName: Renames `color` prop to `colorOverride`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#button-color-prop)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#button-color-prop).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/button-color-prop"
+      transform: "@mui/codemod/node/v5.0.0/button-color-prop"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.ChipVariantProp
 displayName: Updates `variant` prop for Chip component
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#chip-variant-prop)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#chip-variant-prop).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/chip-variant-prop"
+      transform: "@mui/codemod/node/v5.0.0/chip-variant-prop"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.CircularprogressVariant
 displayName: Updates `variant` prop for CircularProgress component
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#circularprogress-variant)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#circularprogress-variant).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/circularprogress-variant"
+      transform: "@mui/codemod/node/v5.0.0/circularprogress-variant"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.CollapseRenameCollapsedheight
 displayName: Renames `collapsedHeight` prop to `transitionCollapsedHeight`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#collapse-rename-collapsedheight)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#collapse-rename-collapsedheight).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/collapse-rename-collapsedheight"
+      transform: "@mui/codemod/node/v5.0.0/collapse-rename-collapsedheight"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.ComponentRenameProp
 displayName: Renames `component` prop to `as`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#component-rename-prop)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#component-rename-prop).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/component-rename-prop"
+      transform: "@mui/codemod/node/v5.0.0/component-rename-prop"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.CoreStylesImport
 displayName: Updates import paths for core styles
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#core-styles-import)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#core-styles-import).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/core-styles-import"
+      transform: "@mui/codemod/node/v5.0.0/core-styles-import"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.CreateTheme
 displayName: Updates createMuiTheme usage
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#create-theme)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#create-theme).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/create-theme"
+      transform: "@mui/codemod/node/v5.0.0/create-theme"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.DatePickersMovedToX
 displayName: Moves date pickers to `@mui/x-date-picker`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#date-pickers-moved-to-x)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#date-pickers-moved-to-x).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/date-pickers-moved-to-x"
+      transform: "@mui/codemod/node/v5.0.0/date-pickers-moved-to-x"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.DialogProps
 displayName: Updates props for Dialog component
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#dialog-props)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#dialog-props).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/dialog-props"
+      transform: "@mui/codemod/node/v5.0.0/dialog-props"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.DialogTitleProps
 displayName: Updates props for DialogTitle component
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#dialog-title-props)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#dialog-title-props).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/dialog-title-props"
+      transform: "@mui/codemod/node/v5.0.0/dialog-title-props"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.EmotionPrependCache
 displayName: Prepends emotion cache
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#emotion-prepend-cache)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#emotion-prepend-cache).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/emotion-prepend-cache"
+      transform: "@mui/codemod/node/v5.0.0/emotion-prepend-cache"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.ExpansionPanelComponent
 displayName: Converts ExpansionPanel to use ExpansionPanel component
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#expansion-panel-component)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#expansion-panel-component).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/expansion-panel-component"
+      transform: "@mui/codemod/node/v5.0.0/expansion-panel-component"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.FabVariant
 displayName: Updates `variant` prop for Fab component
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#fab-variant)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#fab-variant).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/fab-variant"
+      transform: "@mui/codemod/node/v5.0.0/fab-variant"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.FadeRenameAlpha
 displayName: Renames `alpha` prop to `opacity`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#fade-rename-alpha)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#fade-rename-alpha).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/fade-rename-alpha"
+      transform: "@mui/codemod/node/v5.0.0/fade-rename-alpha"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.GridJustifyJustifycontent
 displayName: Updates `justify` prop to `justifyContent` for Grid component
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#grid-justify-justifycontent)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#grid-justify-justifycontent).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/grid-justify-justifycontent"
+      transform: "@mui/codemod/node/v5.0.0/grid-justify-justifycontent"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.GridListComponent
 displayName: Converts GridList to use Grid component
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#grid-list-component)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#grid-list-component).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/grid-list-component"
+      transform: "@mui/codemod/node/v5.0.0/grid-list-component"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.HiddenDownProps
 displayName: Updates `down` prop for Hidden component
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#hidden-down-props)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#hidden-down-props).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/hidden-down-props"
+      transform: "@mui/codemod/node/v5.0.0/hidden-down-props"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.IconButtonSize
 displayName: Updates `size` prop for IconButton component
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#icon-button-size)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#icon-button-size).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/icon-button-size"
+      transform: "@mui/codemod/node/v5.0.0/icon-button-size"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.JoyAvatarRemoveImgprops
 displayName: Removes `imgProps` prop from Avatar component
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#joy-avatar-remove-imgProps)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#joy-avatar-remove-imgProps).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/joy-avatar-remove-imgProps"
+      transform: "@mui/codemod/node/v5.0.0/joy-avatar-remove-imgProps"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.JoyRenameClassnamePrefix
 displayName: Renames `Mui` classname prefix
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#joy-rename-classname-prefix)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#joy-rename-classname-prefix).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/joy-rename-classname-prefix"
+      transform: "@mui/codemod/node/v5.0.0/joy-rename-classname-prefix"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.JoyRenameComponentsToSlots
 displayName: Renames components to slots
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#joy-rename-components-to-slots)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#joy-rename-components-to-slots).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/joy-rename-components-to-slots"
+      transform: "@mui/codemod/node/v5.0.0/joy-rename-components-to-slots"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.JoyRenameRowProp
 displayName: Renames `row` prop to `flexDirection="row"`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#joy-rename-row-prop)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#joy-rename-row-prop).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/joy-rename-row-prop"
+      transform: "@mui/codemod/node/v5.0.0/joy-rename-row-prop"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.JoyTextFieldToInput
 displayName: Renames `TextField` to `Input`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#joy-text-field-to-input)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#joy-text-field-to-input).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/joy-text-field-to-input"
+      transform: "@mui/codemod/node/v5.0.0/joy-text-field-to-input"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.JssToStyled
 displayName: Converts JSS styles to styled-components
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#jss-to-styled)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#jss-to-styled).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/jss-to-styled"
+      transform: "@mui/codemod/node/v5.0.0/jss-to-styled"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.JssToTssReact
 displayName: Converts JSS to TypeScript in React components
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#jss-to-tss-react)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#jss-to-tss-react).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/jss-to-tss-react"
+      transform: "@mui/codemod/node/v5.0.0/jss-to-tss-react"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.LinkUnderlineHover
 displayName: Updates link underline on hover
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#link-underline-hover)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#link-underline-hover).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/link-underline-hover"
+      transform: "@mui/codemod/node/v5.0.0/link-underline-hover"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.MaterialUiStyles
 displayName: Updates usage of `@mui/styles`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#material-ui-styles)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#material-ui-styles).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/material-ui-styles"
+      transform: "@mui/codemod/node/v5.0.0/material-ui-styles"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.MaterialUiTypes
 displayName: Updates usage of `@mui/types`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#material-ui-types)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#material-ui-types).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/material-ui-types"
+      transform: "@mui/codemod/node/v5.0.0/material-ui-types"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.ModalProps
 displayName: Updates props for Modal component
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#modal-props)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#modal-props).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/modal-props"
+      transform: "@mui/codemod/node/v5.0.0/modal-props"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.MovedLabModules
 displayName: Moves lab modules to `@mui/material`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#moved-lab-modules)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#moved-lab-modules).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/moved-lab-modules"
+      transform: "@mui/codemod/node/v5.0.0/moved-lab-modules"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.MuiReplace
 displayName: Replaces `@mui` imports with `@mui/material`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#mui-replace)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#mui-replace).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/mui-replace"
+      transform: "@mui/codemod/node/v5.0.0/mui-replace"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.OptimalImports
 displayName: Optimizes imports
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#optimal-imports)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#optimal-imports).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/optimal-imports"
+      transform: "@mui/codemod/node/v5.0.0/optimal-imports"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.PaginationRoundCircular
 displayName: Updates `circular` prop to `variant="circular"`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#pagination-round-circular)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#pagination-round-circular).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/pagination-round-circular"
+      transform: "@mui/codemod/node/v5.0.0/pagination-round-circular"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.PresetSafe
 displayName: Ensures presets are safe to use
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#preset-safe)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#preset-safe).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/preset-safe"
+      transform: "@mui/codemod/node/v5.0.0/preset-safe"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.RenameCssVariables
 displayName: Renames CSS variables
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#rename-css-variables)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#rename-css-variables).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/rename-css-variables"
+      transform: "@mui/codemod/node/v5.0.0/rename-css-variables"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.RootRef
 displayName: Converts `rootRef` to `ref`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#root-ref)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#root-ref).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/root-ref"
+      transform: "@mui/codemod/node/v5.0.0/root-ref"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.SkeletonVariant
 displayName: Updates `variant` prop for Skeleton component
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#skeleton-variant)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#skeleton-variant).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/skeleton-variant"
+      transform: "@mui/codemod/node/v5.0.0/skeleton-variant"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.StyledEngineProvider
 displayName: Updates usage of styled engine provider
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#styled-engine-provider)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#styled-engine-provider).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/styled-engine-provider"
+      transform: "@mui/codemod/node/v5.0.0/styled-engine-provider"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.TableProps
 displayName: Updates props for Table component
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#table-props)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#table-props).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/table-props"
+      transform: "@mui/codemod/node/v5.0.0/table-props"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.TabsScrollButtons
 displayName: Updates scroll buttons for Tabs component
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#tabs-scroll-buttons)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#tabs-scroll-buttons).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/tabs-scroll-buttons"
+      transform: "@mui/codemod/node/v5.0.0/tabs-scroll-buttons"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.TextareaMinmaxRows
 displayName: Updates `minRows` and `maxRows` props for TextareaAutosize component
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#textarea-minmax-rows)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#textarea-minmax-rows).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/textarea-minmax-rows"
+      transform: "@mui/codemod/node/v5.0.0/textarea-minmax-rows"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.ThemeAugment
 displayName: Adds `DefaultTheme` module augmentation to typescript projects.
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-augment)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-augment).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/theme-augment"
+      transform: "@mui/codemod/node/v5.0.0/theme-augment"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.ThemeBreakpointsWidth
 displayName: Updates `width` values for theme breakpoints
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-breakpoints-width)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-breakpoints-width).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/theme-breakpoints-width"
+      transform: "@mui/codemod/node/v5.0.0/theme-breakpoints-width"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.ThemeBreakpoints
 displayName: Updates theme breakpoints
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-breakpoints)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-breakpoints).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/theme-breakpoints"
+      transform: "@mui/codemod/node/v5.0.0/theme-breakpoints"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.ThemeOptions
 displayName: Updates theme options
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-options)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-options).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/theme-options"
+      transform: "@mui/codemod/node/v5.0.0/theme-options"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.ThemePaletteMode
 displayName: Updates theme palette mode
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-palette-mode)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-palette-mode).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/theme-palette-mode"
+      transform: "@mui/codemod/node/v5.0.0/theme-palette-mode"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.ThemeProvider
 displayName: Updates usage of ThemeProvider
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-provider)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-provider).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/theme-provider"
+      transform: "@mui/codemod/node/v5.0.0/theme-provider"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.ThemeSpacing
 displayName: Updates theme spacing
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-spacing)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-spacing).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/theme-spacing"
+      transform: "@mui/codemod/node/v5.0.0/theme-spacing"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.ThemeTypographyRound
 displayName: Updates `round` values for theme typography
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-typography-round)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-typography-round).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/theme-typography-round"
+      transform: "@mui/codemod/node/v5.0.0/theme-typography-round"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.TopLevelImports
 displayName: Converts all `@mui/material` submodule imports to the root module
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#top-level-imports)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#top-level-imports).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/top-level-imports"
+      transform: "@mui/codemod/node/v5.0.0/top-level-imports"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.Transitions
 displayName: Updates usage of transitions
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#transitions)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#transitions).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/transitions"
+      transform: "@mui/codemod/node/v5.0.0/transitions"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.TreeViewMovedToX
 displayName: Moves tree view to `@mui/x-tree-view`
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#tree-view-moved-to-x)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#tree-view-moved-to-x).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/tree-view-moved-to-x"
+      transform: "@mui/codemod/node/v5.0.0/tree-view-moved-to-x"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.UseAutocomplete
 displayName: Updates usage of useAutocomplete
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#use-autocomplete)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#use-autocomplete).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/use-autocomplete"
+      transform: "@mui/codemod/node/v5.0.0/use-autocomplete"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.UseTransitionprops
 displayName: Updates usage of useTransitionProps
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#use-transitionprops)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#use-transitionprops).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/use-transitionprops"
+      transform: "@mui/codemod/node/v5.0.0/use-transitionprops"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.VariantProp
 displayName: Updates `variant` prop usage
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#variant-prop)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#variant-prop).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/variant-prop"
+      transform: "@mui/codemod/node/v5.0.0/variant-prop"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.WithMobileDialog
 displayName: Updates withMobileDialog higher-order component
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#with-mobile-dialog)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#with-mobile-dialog).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/with-mobile-dialog"
+      transform: "@mui/codemod/node/v5.0.0/with-mobile-dialog"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.WithWidth
 displayName: Updates withWidth higher-order component
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#with-width)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#with-width).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v5.0.0/with-width"
+      transform: "@mui/codemod/node/v5.0.0/with-width"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.OptimalImports
 displayName: Optimizes imports
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#optimal-imports)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#optimal-imports).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v4.0.0/optimal-imports"
+      transform: "@mui/codemod/node/v4.0.0/optimal-imports"
       executable: "@mui/codemod/codemod.js"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.codemods.migrate.mui.ThemeSpacingApi
 displayName: Updates theme spacing API
-description: >
-  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-spacing-api)
+description: >-
+  See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-spacing-api).
 tags:
   - codemods
   - material-ui
   - mui
 recipeList:
   - org.openrewrite.codemods.ApplyCodemod:
-      transform: "v4.0.0/theme-spacing-api"
+      transform: "@mui/codemod/node/v4.0.0/theme-spacing-api"
       executable: "@mui/codemod/codemod.js"

--- a/src/test/java/org/openrewrite/codemods/ApplyCodemodReactMUITest.java
+++ b/src/test/java/org/openrewrite/codemods/ApplyCodemodReactMUITest.java
@@ -1,0 +1,36 @@
+package org.openrewrite.codemods;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.openrewrite.config.Environment;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.test.SourceSpecs.text;
+
+@DisabledIfEnvironmentVariable(named = "CI", matches = "true")
+public class ApplyCodemodReactMUITest implements RewriteTest {
+    @Test
+    void autocompleteRenameCloseicon() {
+        rewriteRun(
+            spec -> spec.recipe(Environment.builder()
+                            .scanRuntimeClasspath()
+                            .build()
+                            .activateRecipes("org.openrewrite.codemods.migrate.mui.AutocompleteRenameCloseicon"))
+                    .typeValidationOptions(TypeValidation.all().immutableExecutionContext(false)),
+            text(
+                """
+                <Autocomplete
+                  closeIcon='toggleInput'
+                />
+                """,
+                """
+                <Autocomplete
+                  clearIcon='toggleInput'
+                />
+                """,
+                spec -> spec.path("src/foo.js")
+            )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/codemods/ApplyCodemodReactMUITest.java
+++ b/src/test/java/org/openrewrite/codemods/ApplyCodemodReactMUITest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.codemods;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
The path in the declarative recipe didn't match the path to the actual transforms under `node_modules`. Maybe this path changed in between versions of Material UI.

I also changed the multi-line description attributes to end with a dot character so that the validation can pass. `>-` here means that it doesn't append another new line (which would fail validation).

Long term, we should probably do the following:

- Write a test case for all recipes to make sure they work as expected
- See if we can run those tests on CI as well. (What's the reason for not running them on CI at the moment?)