### PR TITLE
Upgrade lodash to 4.18.0+ (CVE-2026-4800)

### DIFF
--- a/src/main/resources/codemods/package-lock.json
+++ b/src/main/resources/codemods/package-lock.json
@@ -41,7 +41,7 @@
         "jscodeshift": "^0.16.1",
         "jscodeshift-react-i18next": "github:BartoszJarocki/jscodeshift-react-i18next",
         "json-stable-stringify": "^1.0.2",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.0",
         "putout": "^38.0.6",
         "react": "^18.3.1",
         "slugify": "^1.6.5",
@@ -15805,9 +15805,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {

--- a/src/main/resources/codemods/package.json
+++ b/src/main/resources/codemods/package.json
@@ -6,7 +6,7 @@
     "@next/codemod": "^14.0.4",
     "jscodeshift-react-i18next": "github:BartoszJarocki/jscodeshift-react-i18next",
     "json-stable-stringify": "^1.0.2",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.0",
     "slugify": "^1.6.5",
     "@next/eslint-plugin-next": "^14.1.0",
     "@putout/processor-typescript": "^10.0.0",


### PR DESCRIPTION
## Summary
- Upgrades `lodash` from `^4.17.21` to `^4.18.0` (resolves to 4.18.1)
- Fixes **CVE-2026-4800** (CRITICAL): code injection via `_.template` imports key names
- Also fixes CVE-2025-13465 and CVE-2026-2950 (prototype pollution in `_.unset`/`_.omit`)

## Context
- The OWASP dependency check in [moderneinc/dependency-vulnerability-reports#1039](https://github.com/moderneinc/dependency-vulnerability-reports/issues/1039) flagged this as CRITICAL (CVSS ≥ 9.0), causing the `rewrite-recipe-bom` scan to fail its build.

## Test plan
- [ ] CI passes (build + tests)
- [ ] After merge, rescan `rewrite-recipe-bom` via `rerun-failed-repos.yml` to confirm the CRITICAL CVE is resolved